### PR TITLE
var result was inlined hence obsolete

### DIFF
--- a/The Origins of Reduce.playground/Pages/The Origins of Reduce.xcplaygroundpage/Contents.swift
+++ b/The Origins of Reduce.playground/Pages/The Origins of Reduce.xcplaygroundpage/Contents.swift
@@ -35,7 +35,6 @@ extension List {
     }
     
     func reduce<Result>(_ emptyCase: Result, _ consCase: (Element, Result) -> Result) -> Result {
-        var result = emptyCase
         switch self {
         case .empty:
             return result


### PR DESCRIPTION
var result = emptyCase was inline